### PR TITLE
Use version: ~> 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Recipe for build and integration testing on Travis-CI
 
 # Try beta version of new travis-yml checker
-version: "= 0"
+version: ~> 1.0
 # For extra debugging of failed jobs, see
 # https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image
 


### PR DESCRIPTION
The version requirement `= 0` advertised as an opt-in during early development stages was an unfortunate choice, as this is going to be the opt-out once the new build config validation feature will be rolled out further. Please use `~> 1.0` instead.